### PR TITLE
Update the transferTx method without discarding the original ctx value

### DIFF
--- a/pkg/tm/transaction_executor.go
+++ b/pkg/tm/transaction_executor.go
@@ -205,7 +205,7 @@ func useExistGtx(ctx context.Context, gc *GtxConfig) {
 // transferTx transfer the gtx into a new ctx from old ctx.
 // use it to implement suspend and resume instead of seata java
 func transferTx(ctx context.Context) context.Context {
-	newCtx := InitSeataContext(context.Background())
+	newCtx := InitSeataContext(ctx)
 	SetXID(newCtx, GetXID(ctx))
 	return newCtx
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Update the transferTx method without discarding the original ctx value

**Which issue(s) this PR fixes**:
transferTx discards the ctx value

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```